### PR TITLE
utils/indexmap/indexmap.go: find by hash

### DIFF
--- a/utils/indexmap/indexmap.go
+++ b/utils/indexmap/indexmap.go
@@ -54,7 +54,7 @@ func (m *IndexMap[K, V]) Get(key K) (V, bool) {
 
 func (m *IndexMap[K, V]) Find(key K) (int, bool) {
 	for i, v := range m.InsertOrderList {
-		if v == key {
+		if GetHash(v) == GetHash(key) {
 			return i, true
 		}
 	}

--- a/utils/indexmap/indexmap_test.go
+++ b/utils/indexmap/indexmap_test.go
@@ -76,4 +76,110 @@ func TestIndexMap(t *testing.T) {
 		})
 		require.Equal(t, targetList, testList)
 	})
+
+	t.Run("InsertFull returns correct index", func(t *testing.T) {
+		m := indexmap.NewIndexMap[string, int]()
+
+		// First insertion should return index 0
+		idx := m.InsertFull("key1", 100)
+		require.Equal(t, 0, idx)
+
+		// Second insertion should return index 1
+		idx = m.InsertFull("key2", 200)
+		require.Equal(t, 1, idx)
+
+		// Update of existing key should return original index
+		idx = m.InsertFull("key1", 300)
+		require.Equal(t, 0, idx)
+
+		// Verify the value was updated
+		val, ok := m.Get("key1")
+		require.True(t, ok)
+		require.Equal(t, 300, val)
+	})
+
+	t.Run("InsertFull with equivalent structs", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+			Field2 int
+		}
+
+		m := indexmap.NewIndexMap[TestStruct, string]()
+
+		struct1 := TestStruct{"test", 123}
+		struct2 := TestStruct{"test", 123} // Same values but different instance
+
+		// First insertion
+		idx1 := m.InsertFull(struct1, "value1")
+		require.Equal(t, 0, idx1)
+
+		// Update with equivalent struct shouldn't panic and should return same index
+		idx2 := m.InsertFull(struct2, "value2")
+		require.Equal(t, 0, idx2, "InsertFull should return the same index for equivalent structs")
+
+		// Verify updated value
+		val, ok := m.Get(struct1)
+		require.True(t, ok)
+		require.Equal(t, "value2", val)
+	})
+
+	t.Run("same value different byte arrays", func(t *testing.T) {
+		m := indexmap.NewIndexMap[*[]byte, string]()
+
+		bytes1 := []byte{1, 2, 3}
+		bytes2 := []byte{1, 2, 3}
+
+		m.InsertFull(&bytes1, "value1")
+
+		idx, exists := m.Find(&bytes2)
+		require.True(t, exists, "Should find the key with same values")
+		require.Equal(t, 0, idx, "Index should be 0")
+
+		val, exists := m.Get(&bytes2)
+		require.True(t, exists, "Should get the value with same values")
+		require.Equal(t, "value1", val)
+	})
+
+	t.Run("same value different structs", func(t *testing.T) {
+		type TestStruct struct {
+			Name string
+			ID   int
+		}
+
+		m := indexmap.NewIndexMap[TestStruct, string]()
+
+		struct1 := TestStruct{Name: "test", ID: 123}
+		struct2 := TestStruct{Name: "test", ID: 123}
+
+		m.InsertFull(struct1, "struct-value")
+
+		idx, exists := m.Find(struct2)
+		require.True(t, exists, "Should find the key with same values")
+		require.Equal(t, 0, idx, "Index should be 0")
+
+		val, exists := m.Get(struct2)
+		require.True(t, exists, "Should get the value with same values")
+		require.Equal(t, "struct-value", val)
+	})
+
+	t.Run("InsertFull with different byte arrays with same content", func(t *testing.T) {
+		m := indexmap.NewIndexMap[*[]byte, int]()
+
+		bytes1 := []byte{1, 2, 3, 4, 5}
+		bytes2 := []byte{1, 2, 3, 4, 5}
+
+		idx1 := m.InsertFull(&bytes1, 100)
+		require.Equal(t, 0, idx1)
+
+		idx2 := m.InsertFull(&bytes2, 200)
+		require.Equal(t, 0, idx2, "Should return the same index for equivalent byte arrays")
+
+		val, ok := m.Get(&bytes1)
+		require.True(t, ok)
+		require.Equal(t, 200, val)
+
+		val, ok = m.Get(&bytes2)
+		require.True(t, ok)
+		require.Equal(t, 200, val)
+	})
 }


### PR DESCRIPTION
hi @howjmay, can you take a look? we were running into the panic in InsertFull in some cases eg where the hash for 2 slices are the same, but they point to different addresses. thanks!
