### PR TITLE
sui/suiptb/programmable_transaction_builder.go: fix id comparison

### DIFF
--- a/sui/suiptb/programmable_transaction_builder.go
+++ b/sui/suiptb/programmable_transaction_builder.go
@@ -77,8 +77,11 @@ func (p *ProgrammableTransactionBuilder) Obj(objArg ObjectArg) (Argument, error)
 		}
 
 		switch {
-		case oldObjArg.SharedObject.InitialSharedVersion == objArg.SharedObject.InitialSharedVersion:
-			if oldObjArg.id() != objArg.id() {
+		case oldObjArg.SharedObject != nil && objArg.SharedObject != nil &&
+			oldObjArg.SharedObject.InitialSharedVersion == objArg.SharedObject.InitialSharedVersion:
+			oldId := oldObjArg.id()
+			newId := objArg.id()
+			if oldId != nil && newId != nil && *oldId != *newId {
 				return Argument{}, errors.New("invariant violation! object has id does not match call arg")
 			}
 			oj = ObjectArg{


### PR DESCRIPTION
hi @howjmay , can you take a look?

the id comparison previously did not work, because it's comparing pointers: https://github.com/pattonkan/sui-go/blob/cc4b7c15fea76cd38835f5a5805f027411957304/sui/suiptb/argument.go#L26
