### PR TITLE
fix: Fix cursor type in suix_getCoins's response 

### DIFF
--- a/suiclient/api_coin_query.go
+++ b/suiclient/api_coin_query.go
@@ -46,7 +46,7 @@ func (s *ClientImpl) GetCoinMetadata(ctx context.Context, coinType string) (*Coi
 type GetCoinsRequest struct {
 	Owner    *sui.Address
 	CoinType *sui.ObjectType // optional
-	Cursor   *sui.ObjectId   // optional
+	Cursor   *string         // optional
 	Limit    uint            // optional
 }
 

--- a/suiclient/coin.go
+++ b/suiclient/coin.go
@@ -17,7 +17,7 @@ type Coin struct {
 	PreviousTransaction sui.TransactionDigest `json:"previousTransaction"`
 }
 
-type CoinPage = Page[*Coin, sui.ObjectId]
+type CoinPage = Page[*Coin, string]
 
 func (c *Coin) Ref() *sui.ObjectRef {
 	return &sui.ObjectRef{

--- a/suiclient/conn/http.go
+++ b/suiclient/conn/http.go
@@ -96,7 +96,11 @@ func (c *HttpClient) CallContext(ctx context.Context, result interface{}, method
 	if len(respmsg.Result) == 0 {
 		return ErrNoResult
 	}
-	return json.Unmarshal(respmsg.Result, result)
+	err = json.Unmarshal(respmsg.Result, result)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal result: %w", err)
+	}
+	return nil
 }
 
 // BatchCall sends all given requests as a single batch and waits for the server

--- a/suiclient/page.go
+++ b/suiclient/page.go
@@ -3,7 +3,7 @@ package suiclient
 import "github.com/pattonkan/sui-go/sui"
 
 type Page[T SuiTransactionBlockResponse | Event | Coin | *Coin | SuiObjectResponse | DynamicFieldInfo | string | *Checkpoint,
-	C sui.TransactionDigest | EventId | sui.ObjectId | sui.BigInt] struct {
+	C sui.TransactionDigest | EventId | sui.ObjectId | sui.BigInt | string] struct {
 	Data []T `json:"data"`
 	// 'NextCursor' points to the last item in the page.
 	// Reading with next_cursor will start from the next item after next_cursor


### PR DESCRIPTION
hi @howjmay, suix_getCoins and suix_getAllCoins are broken currently because the cursor type changed from ObjectID to string: https://docs.sui.io/sui-api-ref#suix_getcoins

where previously it was ObjectID: https://docs.blastapi.io/blast-documentation/apis-documentation/core-api/sui/suix_getcoins

nextCursors are no longer addresses:
```
"nextCursor":"eyJjb2luX3R5cGUiOiIweDI6OnN1aTo6U1V..."
```

which returns an error when calling getCoins at the final unmarshal:

```
could not unmarshal result: encoding/hex: invalid byte: U+0079 'y'
```

example request:
```
curl --location 'https://fullnode.mainnet.sui.io/' \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_getCoins",
  "params": [
    "0xc77c9ba2f86fe51cefb7aa340c6956f5c0818f999004389ab95330ba839dfb0c", null, null, 1
  ]                     
}'
```

sui PR that changed it: https://github.com/MystenLabs/sui/pull/21137
